### PR TITLE
Fix files so they can actually be loaded with nano

### DIFF
--- a/etcportage.nanorc
+++ b/etcportage.nanorc
@@ -1,4 +1,3 @@
-Code: /etc/portage/*
 ## Here is an example for Portage control files
 ##
 syntax "/etc/portage" "\.(keywords|mask|unmask|use)(/.+)?$"

--- a/haskell.nanorc
+++ b/haskell.nanorc
@@ -3,7 +3,11 @@
 syntax "haskell" "\.hs$"
 color green "(\||@|!|:|_|~|=|\\|;|\(|\)|,)"
 color magenta "(True|False|==|/=|&&|\|\||<|>|<=|>=)"
-color green "(->|<-|!)" color red 
-"[\n\t](as|case|of|class|data|default|deriving|do|forall|foreign|hiding|if|then|else|import|infix|infixl|infixr|instance|let|in|mdo|module|newtype|qualified|type|where)[ 
-\n\t]" color brightblue "'.'" color brightblue "'\\[ntfr]'" color brightblue ""[^\"]*""
-## Comment highlighting color brightblack "--.*" color brightblack start="\{-" end="-\}"
+color green "(->|<-|!)"
+color red "[\n\t](as|case|of|class|data|default|deriving|do|forall|foreign|hiding|if|then|else|import|infix|infixl|infixr|instance|let|in|mdo|module|newtype|qualified|type|where)[ \n\t]"
+color brightblue "'.'"
+color brightblue "'\\[ntfr]'"
+color brightblue ""[^\"]*""
+## Comment highlighting
+color brightblack "--.*"
+color brightblack start="\{-" end="-\}"


### PR DESCRIPTION
There were some misplaced newlines in `haskell.nanorc`, and a line which I don't think really belongs in `etcportage.nanorc`. This is a quick fix.
