### PR TITLE
Markdown highlighting improvements

### DIFF
--- a/markdown.nanorc
+++ b/markdown.nanorc
@@ -22,7 +22,7 @@ color brightmagenta "\[.*\](\([^\)]*\))?"
 # Link id's:
 color brightmagenta "^\[.*\]:( )+.*"
 # Code spans
-color brightyellow "`.*`"
+color brightyellow "`[^`]*`"
 # Code blocks
 # disabled, because indented lines aren't always code blocks
 # color brightyellow "^(    ).*"


### PR DESCRIPTION
- Fixing the emphasis regexes like `* ** _` when multiple words are emphasized on the same line
- Smarter link regexes
- Highlighting numbered and bulleted lists
