### PR TITLE
markdown.nanorc: don't mark .t(e)xt files as Markdown

### DIFF
--- a/markdown.nanorc
+++ b/markdown.nanorc
@@ -1,4 +1,4 @@
-syntax "markdown" "\.txt$" "\.text$" "\.md$" "\.markdown$"
+syntax "markdown" "\.md$" "\.markdown$"
 
 ## Quotations
 color cyan "^>.*"


### PR DESCRIPTION
`.txt` and `.text` are generic plain text extensions that are not necessarily formatted using Markdown. This prevents extraneous highlighting from showing up when this is in fact the case.