### PR TITLE
Update python.nanorc

### DIFF
--- a/python.nanorc
+++ b/python.nanorc
@@ -1,7 +1,23 @@
 syntax "python" "\.py$"
-icolor brightblue "def [0-9A-Z_]+"
-color brightcyan "\<(and|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|map|not|or|pass|print|raise|return|try|while)\>"
+icolor brightred "def [ 0-9A-Z_]+"
+
+## Python keywords
+color brightcyan "\<(and|as|assert|class|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|map|not|or|pass|print|raise|try|while|with|yield)\>"
+color brightmagenta "\<(break|continue|return)\>"
+
+# Python objects
+color red "\<(str|bytearray|bytes|list|tuple|set|frozenset|dict|int|float|complex|bool)\>"
+
+## Operators
+color yellow "[.:;,+*|=!\%]" "<" ">" "/" "-" "&"
+
+## Braces and parentheses
+color magenta "[(){}]" "\[" "\]"
+
+# Python strings
 color brightgreen "['][^']*[^\\][']" "[']{3}.*[^\\][']{3}"
 color brightgreen "["][^"]*[^\\]["]" "["]{3}.*[^\\]["]{3}"
 color brightgreen start=""""[^"]" end=""""" start="'''[^']" end="'''"
-color brightred "#.*$"
+
+## Comments
+color brightblue "#.*$"


### PR DESCRIPTION
Updating python.nanorc to better match cython.nanorc (where relevant).
Cython had a more complete syntax highlighting definition, and this just tries to bring python syntax highlighting to match it.