### PR TITLE
Update conf.nanorc

### DIFF
--- a/conf.nanorc
+++ b/conf.nanorc
@@ -5,13 +5,13 @@ icolor yellow ""(\\.|[^"])*""
 
 # Variable name and value
 icolor brightyellow start="=" end="$"
-icolor magenta start="(^|[[:space:]])[0-9a-z-]" end="="
+icolor magenta start="^[[:space:]]*[0-9a-z-]" end="="
 
 # Braces and parentheses
 icolor brightred "(^|[[:space:]])((\[|\()[0-9a-z_!@#$%^&*-]+(\]|\)))"
 
 # Numbers
-color green "[[:space:]][0-9.KM]+"
+icolor green "[[:space:]][0-9]+[0-9.]*[KMGT]*"
 
 # Comments
 color cyan start="(^|[[:space:]])(#|;).*$" end="$"


### PR DESCRIPTION
1) The parameter name rule was overriding the parameter value rule, so you would get magenta = magenta, instead of magenta = yellow; it is now anchored to the start of a line; this can also be achieved by reversing the icolor brightyellow and icolor magenta lines (which puts the equals also in yellow, which I prefer not to have) — **Edit:** this resolves compatibility with GNU nano 2.0.9 in CentOS 6.8; I see that the original rule appears to work fine in Debian 8's GNU nano 2.2.6

2) The number rule didn't require numbers to start with digits, and it was not accepting lowercase suffixes; I've added a couple more suffixes as well for good measure