### PR TITLE
bugfix ini: on/off matched inside words

### DIFF
--- a/ini.nanorc
+++ b/ini.nanorc
@@ -10,7 +10,7 @@ color green "="
 color brightblue "-?[0-9\.]+\s*($|;)"
 
 ## ON/OFF
-color brightmagenta "ON|OFF|On|Off|on|off\s*($|;)"
+color brightmagenta "(ON|OFF|On|Off|on|off)\s*($|;)"
 
 ## Sections
 color brightcyan "^\s*\[.*\]"


### PR DESCRIPTION
put or-parts in parentheses, so the end-matcher is used on all parts, not just the last part