### PR TITLE
Added ES6 back-tick support.

### DIFF
--- a/js.nanorc
+++ b/js.nanorc
@@ -23,6 +23,8 @@ color red "\<(true|false)\>"
 ## String
 color brightyellow "L?\"(\\"|[^"])*\""
 color brightyellow "L?'(\'|[^'])*'"
+color brightcyan "L?`(\`|[^`])*`"
+color ,magenta "\$\{(.+)\}"
 
 ## Escapes
 color red "\\[0-7][0-7]?[0-7]?|\\x[0-9a-fA-F]+|\\[bfnrt'"\?\\]"


### PR DESCRIPTION
Supports for ES6 template string literals like:
```es6
`Page is visited ${count} times.`
```