### PR TITLE
Added .jsx

### DIFF
--- a/js.nanorc
+++ b/js.nanorc
@@ -1,4 +1,4 @@
-syntax "javascript" "\.(mjs)|(js)|(json)$"
+syntax "javascript" "\.(mjs)|(js)|(jsx)|(json)$"
 
 ## Default
 color white "^.+$"


### PR DESCRIPTION
Airbnb React style guide requires React components to be saved as .jsx.