### PR TITLE
Update pony.nanorc

### DIFF
--- a/pony.nanorc
+++ b/pony.nanorc
@@ -36,7 +36,7 @@ color Yellow "\<[A-Z][a-zA-Z0-9_\-]+(\(|\.)"
 color brightblue "\<[a-zA-Z0-9_\-]+\("
 
 ## white dots and parentessis
-color brightwhite "[.:()&*=+-|{}%<>!@]"
+color brightwhite "[.:()&*=+\-\|{}%<>!@]"
 color brightwhite "(\\|/|\[|\])"
 color brightwhite " (xor|or|and|not) "
 


### PR DESCRIPTION
Fixed regex for dots and parentheses
regex no longer overrides the previous ones