### PR TITLE
Force unix line endings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,2 @@
-[*.bashrc]
+[*]
 end_of_line = lf

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.bashrc]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-# Auto detect text files and perform LF normalization
-* text=auto
-
-# Force unix line endings for bashrc
-*.bashrc text eol=lf
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Force unix line endings for bashrc
+*.bashrc text eol=lf


### PR DESCRIPTION
Nano can't load the files when the line endings aren't lf, but on windows when cloning the repo they're crlf. This should force them to be unix style