### PR TITLE
Syntax Highlighting for Batch-file Shell Script

### DIFF
--- a/batch.nanorc
+++ b/batch.nanorc
@@ -1,0 +1,34 @@
+## Here is an example for Batch file shell script.
+## Author: davidhcefx (https://github.com/davidhcefx), based on Mitch Bumgarner's version.
+## License: MIT License
+
+syntax "batch" "\.(bat|cmd)$"
+header "^@[eE](cho|CHO) (on|off|ON|OFF)"
+comment "::"
+
+# Native commands, symbols, and comparisons.
+icolor green "\<(ASSOC|CALL|CD|CLS|CMDEXTVERSION|COLOR|COPY|DATE|DEL|DIR|ECHO|ENDLOCAL|ERASE|ERRORLEVEL|EXIT|FOR|FTYPE|GOTO|IF|MD|MKLINK|MOVE|PATH|PAUSE|POPD|PROMPT|PUSHD|RD|REM|REN|SET|SETLOCAL|SHIFT|START|TIME|TITLE|TYPE|VER|VERIFY|VOL)\>"
+icolor green "\<(EQU|NEQ|LSS|LEQ|GTR|GEQ|DEFINED|EXIST|NOT)\>"
+color  green "[:|<>=&@\\^]"
+
+# Options.
+color brightmagenta "[[:blank:]]/[A-Za-z]+\>"
+
+# Common commands. (with Sublime and Github highlighting as a reference)
+icolor brightblue "\<(APPEND|ARP|AT|ATTRIB|AUTOFAIL|BACKUP|BCDBOOT|BCDEDIT|BITSADMIN|BREAK|CACLS|CERTREQ|CERTUTIL|CHANGE|CHCP|CHDIR|CHKDSK|CHKNTFS|CHOICE|CIPHER|CleanMgr|CLIP|CMD|CMDKEY|COMP|COMPACT|CONVERT|CSVDE|DEFRAG|DELTREE|DevCon|DIRQUOTA|DISKCOMP|DISKCOPY|DISKPART|DISKSHADOW|DNSCMD|DOSKEY|DriverQuery|DSACLs|DSAdd|DSGet|DSQuery|DSMod|DSMove|DSRM|Dsmgmt|EVENTCREATE|EXPAND|EXPLORER|EXTRACT|FC|FIND|FINDSTR|FORFILES|FORMAT|FREEDISK|FSUTIL|FTP|GETMAC|GPRESULT|GPUPDATE|GRAFTABL|HELP|HOSTNAME|iCACLS|IEXPRESS|IPCONFIG|INUSE|KEYB|LABEL|LODCTR|LOGMAN|LOGOFF|MAKECAB|MKDIR|MODE|MORE|MOUNTVOL|MSG|MSIEXEC|MSINFO32|MSTSC|NET|NETDOM|NETSH|NBTSTAT|NETSTAT|NLTEST|NSLOOKUP|NTBACKUP|NTDSUtil|OPENFILES|PATHPING|PING|POWERCFG|PRINT|PRNCNFG|PRNMNGR|Query|RASDIAL|RASPHONE|RECOVER|REG|REGEDIT|REGSVR32|REGINI|RENAME|REPLACE|Reset|RESTORE|RMDIR|ROBOCOPY|ROUTE|RUNAS|RUNDLL32|SC|SCHTASKS|SetSPN|SETX|SFC|SHUTDOWN|SORT|SSH|SUBINACL|SUBST|SYSTEMINFO|TAKEOWN|TASKLIST|TASKKILL|TELNET|TIMEOUT|TRACERT|TREE|TSDISCON|TSKILL|TypePerf|TZUTIL|VSSADMIN|W32TM|WAITFOR|WBADMIN|WECUTIL|WEVTUTIL|WHERE|WHOAMI|WINRM|WINRS|WMIC|XCACLS|XCOPY)\>"
+
+# Variable names. (spaces not allowed)
+color brightred "%([[:alpha:]`~@#$*(){}:',.?+=_-]|\[|\])([[:alnum:]`~@#$*(){}:',.?+=_-]|\[|\])*%"
+color brightred "!([[:alnum:]`~@#$%*(){}:',.?+=_-]|\[|\])([[:alnum:]`~@#$%*(){}:',.?+=_-]|\[|\])*!"
+
+# Parameter names for arguments and loop.
+color brightred "%(~[[:alpha:]$]*)?[0-9*]\>" "%%(~[[:alpha:]$]*)?[[:alpha:]]\>"
+
+# Comments.
+icolor cyan "^[[:space:]]*(\<rem\>|::).*"
+
+# Strings.
+icolor brightyellow ""(\^.|[^"])*""
+
+# Trailling whitespace
+color ,green "[[:space:]]+$"

--- a/batch.nanorc
+++ b/batch.nanorc
@@ -4,7 +4,7 @@
 
 syntax "batch" "\.(bat|cmd)$"
 header "^@[eE](cho|CHO) (on|off|ON|OFF)"
-comment "::"
+comment "REM "
 
 # Native commands, symbols, and comparisons.
 icolor green "\<(ASSOC|CALL|CD|CLS|CMDEXTVERSION|COLOR|COPY|DATE|DEL|DIR|ECHO|ENDLOCAL|ERASE|ERRORLEVEL|EXIT|FOR|FTYPE|GOTO|IF|MD|MKLINK|MOVE|PATH|PAUSE|POPD|PROMPT|PUSHD|RD|REM|REN|SET|SETLOCAL|SHIFT|START|TIME|TITLE|TYPE|VER|VERIFY|VOL)\>"


### PR DESCRIPTION
# Features
- A complete list of native cmd commands, extracted from [SS64](https://ss64.com/nt/).
  - 40 native commands + 151 common commands.
- Conformed to the color-coding convention as of [sh.nanorc](https://git.savannah.gnu.org/cgit/nano.git/tree/syntax/sh.nanorc).
- Detect syntax from the `@ECHO OFF` header automatically.
- Can highlight variable names such as `%var%` or `!long_%name%_with_delayed_expansion!`.
- Comment out a line with `::` automatically when keybinding been pressed.
- Visit my repo: https://github.com/davidhcefx/Nano-Syntax-Highlighting_Batch-File/

# Screenshot
<img src="https://raw.githubusercontent.com/davidhcefx/Nano-Syntax-Highlighting_Batch-File/master/res/scnshot.png" width=600>

# References
- [nanorc (5) - Linux Man Page](https://www.systutorials.com/docs/linux/man/5-nanorc/)
- [Windows CMD - SS64](https://ss64.com/nt/)
- [Windows Commands - Microsoft Docs](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/for)
- [mitchell486/nanorc/bat.nanorc](https://github.com/mitchell486/nanorc)
- https://github.com/scopatz/nanorc/pull/331