### PR TITLE
Fix rcfile-new and bash syntax (#51)

### DIFF
--- a/bash.nanorc
+++ b/bash.nanorc
@@ -1,4 +1,6 @@
-syntax "bash" "\.sh$" "\.bash$" "/.bash_profile$" "(\.|/)profile$" "\rc$" "(\.|/)control$"
+# Bash only syntax highlighting
+#
+syntax "bash" "\.bash$" "\.bash_(profile|aliases|functions|login|logout)$" "(\.|/)profile$"
 header "^#!.*/(ba|k|pdk)?sh[-0-9_]*"
 
 ## Control

--- a/rcfiles-new.nanorc
+++ b/rcfiles-new.nanorc
@@ -8,7 +8,7 @@ color yellow "(#(define|include)|LANGUAGE|FONT)"
 
 ### all *rc files  ( e.g. .bashrc, inputrc, xtermcontrol .... )
 #syntax "rcfiles" "(\.|/)rc$" "(\.|/)control$"
-syntax "rcfiles" "((.ba|ba|c|.c)sh|input|xinit|eix|(.w|w)minet)|gtk|rc$"
+syntax "rcfiles" "\.?((ba|c|z)sh|input|xinit|eix|wminet|gtk)rc$"
 color red "'(\\.|[^'])*'"
 color blue ""(\\.|[^\"])*""
 color magenta "[A-Z0-9\_]+="


### PR DESCRIPTION
- Fix broken syntax of rcfile-new
- Restrict bash syntax to bash-only to avoid colliding with sh